### PR TITLE
add 'void' to to remove compiler warning

### DIFF
--- a/include/bitset.h
+++ b/include/bitset.h
@@ -18,7 +18,7 @@ struct bitset_s {
 typedef struct bitset_s bitset_t;
 
 /* Create a new bitset. Return NULL in case of failure. */
-bitset_t *bitset_create();
+bitset_t *bitset_create( void );
 
 /* Create a new bitset able to contain size bits. Return NULL in case of failure. */
 bitset_t *bitset_create_with_capacity( size_t size );


### PR DESCRIPTION
Removes the compiler warning (gcc v.7.3.0) 

```
cbitset/src/bitset.c:10:11: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
```