### PR TITLE
Change 'make clean' to remove all executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ lemirebenchmark: bitset.o ./benchmarks/lemirebenchmark.c $(HEADERS)
 benchmark: bitset.o ./benchmarks/benchmark.c $(HEADERS)
 	$(CC) $(CFLAGS) -o benchmark ./benchmarks/benchmark.c bitset.o -Iinclude
 clean:
-	rm -f  *.o unit benchmark
+	rm -f  *.o unit benchmark lemirebenchmark


### PR DESCRIPTION
Changes 'make clean' to remove the lemirebenchmark executable in addition to unit and benchmark.