### PR TITLE
Compatibility with MSVC for the use of `restrict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ make
 ./unit
 ```
 
-Prerequisites: C11-compatible compiler
+Prerequisites: C11-compatible compiler (MSVC Users, please have a look at [C11 and C17 Standard Support Arriving in MSVC](https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/)).
 

--- a/include/bitset.h
+++ b/include/bitset.h
@@ -9,7 +9,7 @@
 #include "portability.h"
 
 struct bitset_s {
-    uint64_t * RESTRICT array;
+    uint64_t * CBITSET_RESTRICT array;
     size_t arraysize;
     size_t capacity;
 
@@ -126,16 +126,16 @@ size_t bitset_maximum(const bitset_t *bitset);
 
 
 /* compute the union in-place (to b1), returns true if successful, to generate a new bitset first call bitset_copy */
-bool bitset_inplace_union(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
+bool bitset_inplace_union(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2);
 
 /* report the size of the union (without materializing it) */
-size_t bitset_union_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
+size_t bitset_union_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2);
 
 /* compute the intersection in-place (to b1), to generate a new bitset first call bitset_copy */
-void bitset_inplace_intersection(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
+void bitset_inplace_intersection(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2);
 
 /* report the size of the intersection (without materializing it) */
-size_t bitset_intersection_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
+size_t bitset_intersection_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2);
 
 
 /* returns true if the bitsets contain no common elements */
@@ -149,16 +149,16 @@ bool bitset_contains_all(const bitset_t * b1, const bitset_t * b2);
 
 
 /* compute the difference in-place (to b1), to generate a new bitset first call bitset_copy */
-void bitset_inplace_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
+void bitset_inplace_difference(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2);
 
 /* compute the size of the difference */
-size_t  bitset_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) ;
+size_t  bitset_difference_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) ;
 
 /* compute the symmetric difference in-place (to b1), return true if successful, to generate a new bitset first call bitset_copy */
-bool bitset_inplace_symmetric_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
+bool bitset_inplace_symmetric_difference(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2);
 
 /* compute the size of the symmetric difference  */
-size_t  bitset_symmetric_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
+size_t  bitset_symmetric_difference_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2);
 
 /* iterate over the set bits
  like so :

--- a/include/bitset.h
+++ b/include/bitset.h
@@ -9,7 +9,7 @@
 #include "portability.h"
 
 struct bitset_s {
-    uint64_t * restrict array;
+    uint64_t * RESTRICT array;
     size_t arraysize;
     size_t capacity;
 
@@ -126,16 +126,16 @@ size_t bitset_maximum(const bitset_t *bitset);
 
 
 /* compute the union in-place (to b1), returns true if successful, to generate a new bitset first call bitset_copy */
-bool bitset_inplace_union(bitset_t * restrict b1, const bitset_t * restrict b2);
+bool bitset_inplace_union(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
 
 /* report the size of the union (without materializing it) */
-size_t bitset_union_count(const bitset_t * restrict b1, const bitset_t * restrict b2);
+size_t bitset_union_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
 
 /* compute the intersection in-place (to b1), to generate a new bitset first call bitset_copy */
-void bitset_inplace_intersection(bitset_t * restrict b1, const bitset_t * restrict b2);
+void bitset_inplace_intersection(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
 
 /* report the size of the intersection (without materializing it) */
-size_t bitset_intersection_count(const bitset_t * restrict b1, const bitset_t * restrict b2);
+size_t bitset_intersection_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
 
 
 /* returns true if the bitsets contain no common elements */
@@ -149,16 +149,16 @@ bool bitset_contains_all(const bitset_t * b1, const bitset_t * b2);
 
 
 /* compute the difference in-place (to b1), to generate a new bitset first call bitset_copy */
-void bitset_inplace_difference(bitset_t * restrict b1, const bitset_t * restrict b2);
+void bitset_inplace_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
 
 /* compute the size of the difference */
-size_t  bitset_difference_count(const bitset_t *restrict b1, const bitset_t * restrict b2) ;
+size_t  bitset_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) ;
 
 /* compute the symmetric difference in-place (to b1), return true if successful, to generate a new bitset first call bitset_copy */
-bool bitset_inplace_symmetric_difference(bitset_t * restrict b1, const bitset_t * restrict b2);
+bool bitset_inplace_symmetric_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
 
 /* compute the size of the symmetric difference  */
-size_t  bitset_symmetric_difference_count(const bitset_t *restrict b1, const bitset_t * restrict b2);
+size_t  bitset_symmetric_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2);
 
 /* iterate over the set bits
  like so :

--- a/include/portability.h
+++ b/include/portability.h
@@ -3,11 +3,11 @@
 #include <stdint.h>
 
 // For compatibility with MSVC with the use of `restrict`
-#if defined(__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && defined(__STDC_VERSION__ ))
+#if (__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && defined(__STDC_VERSION__ ))
 #define CBITSET_RESTRICT restrict
 #else
 #define CBITSET_RESTRICT
-#endif // defined(__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && defined(__STDC_VERSION__ ))
+#endif // (__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && defined(__STDC_VERSION__ ))
 
 #ifdef _MSC_VER
 /* Microsoft C/C++-compatible compiler */

--- a/include/portability.h
+++ b/include/portability.h
@@ -3,13 +3,11 @@
 #include <stdint.h>
 
 // For compatibility with MSVC with the use of `restrict`
-#if defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__) || (__STDC_VERSION__ >= 199901L)
+#if defined(__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && defined(__STDC_VERSION__ ))
 #define CBITSET_RESTRICT restrict
-#elif defined(_MSC_VER)
-#define CBITSET_RESTRICT __restrict
 #else
-#define RESTRICT
-#endif // defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__) || (__STDC_VERSION__ >= 199901L)
+#define CBITSET_RESTRICT
+#endif // defined(__STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && defined(__STDC_VERSION__ ))
 
 #ifdef _MSC_VER
 /* Microsoft C/C++-compatible compiler */

--- a/include/portability.h
+++ b/include/portability.h
@@ -2,7 +2,7 @@
 #define CBITSET_PORTABILITY_H
 #include <stdint.h>
 
-// For compatibility with MSVC with teh use of `restrict`
+// For compatibility with MSVC with the use of `restrict`
 #if defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)
 #define RESTRICT restrict
 #elif defined(_MSC_VER)

--- a/include/portability.h
+++ b/include/portability.h
@@ -4,9 +4,9 @@
 
 // For compatibility with MSVC with the use of `restrict`
 #if defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)
-#define RESTRICT restrict
+#define CBITSET_RESTRICT restrict
 #elif defined(_MSC_VER)
-#define RESTRICT __restrict
+#define CBITSET_RESTRICT __restrict
 #else
 #define RESTRICT
 #endif // defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)

--- a/include/portability.h
+++ b/include/portability.h
@@ -3,13 +3,13 @@
 #include <stdint.h>
 
 // For compatibility with MSVC with the use of `restrict`
-#if defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)
+#if defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__) || (__STDC_VERSION__ >= 199901L)
 #define CBITSET_RESTRICT restrict
 #elif defined(_MSC_VER)
 #define CBITSET_RESTRICT __restrict
 #else
 #define RESTRICT
-#endif // defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)
+#endif // defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__) || (__STDC_VERSION__ >= 199901L)
 
 #ifdef _MSC_VER
 /* Microsoft C/C++-compatible compiler */

--- a/include/portability.h
+++ b/include/portability.h
@@ -2,6 +2,15 @@
 #define CBITSET_PORTABILITY_H
 #include <stdint.h>
 
+// For compatibility with MSVC with teh use of `restrict`
+#if defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)
+#define RESTRICT restrict
+#elif defined(_MSC_VER)
+#define RESTRICT __restrict
+#else
+#define RESTRICT
+#endif // defined(__INTEL_COMPILER) || defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)
+
 #ifdef _MSC_VER
 /* Microsoft C/C++-compatible compiler */
 #include <intrin.h>

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -28,11 +28,10 @@ bitset_t *bitset_create_with_capacity( size_t size ) {
   }
   bitset->arraysize = (size + sizeof(uint64_t) * 8 - 1) / (sizeof(uint64_t) * 8);
   bitset->capacity = bitset->arraysize;
-  if ((bitset->array = (uint64_t *) malloc(sizeof(uint64_t) * bitset->arraysize)) == NULL) {
+  if ((bitset->array = (uint64_t *) calloc(sizeof(uint64_t) * bitset->arraysize)) == NULL) {
     free( bitset);
     return NULL;
   }
-  memset(bitset->array,0,sizeof(uint64_t) * bitset->arraysize);
   return bitset;
 }
 

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -245,7 +245,7 @@ bool bitset_contains_all(const bitset_t * b1, const bitset_t * b2) {
   return true;
 }
 
-size_t bitset_union_count(const bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
+size_t bitset_union_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t answer = 0;
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
@@ -304,7 +304,7 @@ size_t bitset_intersection_count(const bitset_t * RESTRICT b1, const bitset_t * 
   return answer;
 }
 
-void bitset_inplace_difference(bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
+void bitset_inplace_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -313,7 +313,7 @@ void bitset_inplace_difference(bitset_t *RESTRICT b1, const bitset_t * RESTRICT 
 }
 
 
-size_t  bitset_difference_count(const bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
+size_t  bitset_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   size_t answer = 0;
@@ -326,7 +326,7 @@ size_t  bitset_difference_count(const bitset_t *RESTRICT b1, const bitset_t * RE
   return answer;
 }
 
-bool bitset_inplace_symmetric_difference(bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
+bool bitset_inplace_symmetric_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -340,7 +340,7 @@ bool bitset_inplace_symmetric_difference(bitset_t *RESTRICT b1, const bitset_t *
   return true;
 }
 
-size_t  bitset_symmetric_difference_count(const bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
+size_t  bitset_symmetric_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   size_t answer = 0;

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -28,7 +28,7 @@ bitset_t *bitset_create_with_capacity( size_t size ) {
   }
   bitset->arraysize = (size + sizeof(uint64_t) * 8 - 1) / (sizeof(uint64_t) * 8);
   bitset->capacity = bitset->arraysize;
-  if ((bitset->array = (uint64_t *) calloc(sizeof(uint64_t) * bitset->arraysize)) == NULL) {
+  if ((bitset->array = (uint64_t *) calloc(bitset->arraysize, sizeof(uint64_t))) == NULL) {
     free( bitset);
     return NULL;
   }

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -156,7 +156,7 @@ size_t bitset_count(const bitset_t *bitset) {
 }
 
 
-bool bitset_inplace_union(bitset_t * restrict b1, const bitset_t * restrict b2) {
+bool bitset_inplace_union(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   for(size_t k = 0 ; k < minlength; ++k) {
     b1->array[k] |= b2->array[k];
@@ -245,7 +245,7 @@ bool bitset_contains_all(const bitset_t * b1, const bitset_t * b2) {
   return true;
 }
 
-size_t bitset_union_count(const bitset_t *restrict b1, const bitset_t * restrict b2) {
+size_t bitset_union_count(const bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t answer = 0;
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
@@ -284,7 +284,7 @@ size_t bitset_union_count(const bitset_t *restrict b1, const bitset_t * restrict
   return answer;
 }
 
-void bitset_inplace_intersection(bitset_t * restrict b1, const bitset_t * restrict b2) {
+void bitset_inplace_intersection(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -295,7 +295,7 @@ void bitset_inplace_intersection(bitset_t * restrict b1, const bitset_t * restri
   }
 }
 
-size_t bitset_intersection_count(const bitset_t * restrict b1, const bitset_t * restrict b2) {
+size_t bitset_intersection_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t answer = 0;
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   for(size_t k = 0 ; k < minlength; ++k) {
@@ -304,7 +304,7 @@ size_t bitset_intersection_count(const bitset_t * restrict b1, const bitset_t * 
   return answer;
 }
 
-void bitset_inplace_difference(bitset_t *restrict b1, const bitset_t * restrict b2) {
+void bitset_inplace_difference(bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -313,7 +313,7 @@ void bitset_inplace_difference(bitset_t *restrict b1, const bitset_t * restrict 
 }
 
 
-size_t  bitset_difference_count(const bitset_t *restrict b1, const bitset_t * restrict b2) {
+size_t  bitset_difference_count(const bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   size_t answer = 0;
@@ -326,7 +326,7 @@ size_t  bitset_difference_count(const bitset_t *restrict b1, const bitset_t * re
   return answer;
 }
 
-bool bitset_inplace_symmetric_difference(bitset_t *restrict b1, const bitset_t * restrict b2) {
+bool bitset_inplace_symmetric_difference(bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -340,7 +340,7 @@ bool bitset_inplace_symmetric_difference(bitset_t *restrict b1, const bitset_t *
   return true;
 }
 
-size_t  bitset_symmetric_difference_count(const bitset_t *restrict b1, const bitset_t * restrict b2) {
+size_t  bitset_symmetric_difference_count(const bitset_t *RESTRICT b1, const bitset_t * RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   size_t answer = 0;

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -155,7 +155,7 @@ size_t bitset_count(const bitset_t *bitset) {
 }
 
 
-bool bitset_inplace_union(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+bool bitset_inplace_union(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   for(size_t k = 0 ; k < minlength; ++k) {
     b1->array[k] |= b2->array[k];
@@ -244,7 +244,7 @@ bool bitset_contains_all(const bitset_t * b1, const bitset_t * b2) {
   return true;
 }
 
-size_t bitset_union_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+size_t bitset_union_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t answer = 0;
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
@@ -283,7 +283,7 @@ size_t bitset_union_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRIC
   return answer;
 }
 
-void bitset_inplace_intersection(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+void bitset_inplace_intersection(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -294,7 +294,7 @@ void bitset_inplace_intersection(bitset_t * RESTRICT b1, const bitset_t * RESTRI
   }
 }
 
-size_t bitset_intersection_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+size_t bitset_intersection_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t answer = 0;
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   for(size_t k = 0 ; k < minlength; ++k) {
@@ -303,7 +303,7 @@ size_t bitset_intersection_count(const bitset_t * RESTRICT b1, const bitset_t * 
   return answer;
 }
 
-void bitset_inplace_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+void bitset_inplace_difference(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -312,7 +312,7 @@ void bitset_inplace_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT
 }
 
 
-size_t  bitset_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+size_t  bitset_difference_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   size_t answer = 0;
@@ -325,7 +325,7 @@ size_t  bitset_difference_count(const bitset_t * RESTRICT b1, const bitset_t * R
   return answer;
 }
 
-bool bitset_inplace_symmetric_difference(bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+bool bitset_inplace_symmetric_difference(bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   for( ; k < minlength; ++k) {
@@ -339,7 +339,7 @@ bool bitset_inplace_symmetric_difference(bitset_t * RESTRICT b1, const bitset_t 
   return true;
 }
 
-size_t  bitset_symmetric_difference_count(const bitset_t * RESTRICT b1, const bitset_t * RESTRICT b2) {
+size_t  bitset_symmetric_difference_count(const bitset_t * CBITSET_RESTRICT b1, const bitset_t * CBITSET_RESTRICT b2) {
   size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
   size_t k = 0;
   size_t answer = 0;


### PR DESCRIPTION
Added a macro to support the use of `restrict` in MSVC.

Following on https://github.com/lemire/cbitset/issues/8.